### PR TITLE
Rivendell volunteers

### DIFF
--- a/common/national_focus/rivendell.txt
+++ b/common/national_focus/rivendell.txt
@@ -774,7 +774,6 @@ focus_tree = {
 			}
 			add_ideas = militarism_focus
 			army_experience = 20
-			set_rule = { can_send_volunteers = yes }
 			add_ideas = wartime_industry_focus
 		}
 	}

--- a/common/national_focus/rivendell.txt
+++ b/common/national_focus/rivendell.txt
@@ -43,7 +43,10 @@ focus_tree = {
 		prerequisite = { focus = thefateofrivendell}
 		cost = 10
 		available_if_capitulated = yes
-		completion_reward = { add_ideas = RIV_collaboration_focus }
+		completion_reward = { 
+			add_ideas = RIV_collaboration_focus 
+			set_rule = { can_send_volunteers = yes }
+		}
 	}
 
 	#Focus for Trade Reforms


### PR DESCRIPTION
closes #133 
* Allows collaborative rivendell to send voluteers 
* Removes a redundant allow volunteers rule for belligerent rivendell 

In regards to comments form Helliaca about the Grey Company focus in the previous pull request (134), I think it is a good idea, but I think its more complicated that just duplicating the focus to Rivendell. For now I think it is too difficult a change for where I am at in terms of modding skills. 